### PR TITLE
Cleanup for streamgraph, viz1, viz3, viz4

### DIFF
--- a/dataExt/streamgraph.html
+++ b/dataExt/streamgraph.html
@@ -1,14 +1,15 @@
 <!DOCTYPE html>
-<meta charset="utf-8">
+<meta charset="utf-8" xmlns="http://www.w3.org/1999/html" xmlns="http://www.w3.org/1999/html">
 <style>
 
 body {
   font: 12px verdana;
 }
 
-.chart { 
+.chart {
   background: #fff;
 }
+
 
 p {
   font: 14px verdana;
@@ -24,15 +25,35 @@ p {
 
 button {
   position: absolute;
-  right: 50px;
-  top: 10px;
 }
 
 </style>
+
 <body>
 <script type=text/javascript src="https://d3js.org/d3.v3.js"></script>
+<div class="title"></div>
+<p
+  <label for="sgtitle"
+         style="font-family: verdana,serif;
+                width: 900px;
+                margin-left: 0;
+                margin-right: 0;
+                font-size: 22px;
+                text-align: center">
+         Top Domains by <span id="sgtitle-value"></span> per Day
+  </label>
+</p>
+<div class="chart"></div>
 
-
-<div class="chart">
-</div>
+<p>
+  <label for="nDomains"
+         style="display: inline-block;
+                width: 160px;
+                font-family: verdana,serif;
+                font-size: 12px;
+                text-align: right">
+         Top domains = <span id="nDomains-value"> </span>
+  </label>
+  <input type="range" min="1" max="100" id="nDomains">
+</p>
 <script type="text/javascript" src="streamgraphD3.js"></script>

--- a/dataExt/timeofdayD3.js
+++ b/dataExt/timeofdayD3.js
@@ -2,85 +2,93 @@
 // Coopey's Block 6382449
 // https://bl.ocks.org/mbostock/d8bcc4b130df420d6c40
 
-/* Overall strategy
- *  1. Send message to the listener on background page to send query data
- * 	2. Display the scatterplot visualization using D3
- */
+// Overall strategy
+//  1. Send message to the listener on background page to send query data
+// 	2. Display the scatterplot visualization using D3
 var w = 800;
 var h = 500;
- 
+
 //  1. Send message to the listener on background page to send query data
-chrome.runtime.sendMessage({greeting: "timeOfDayD3"}, function(response) {
-var data = response.timeSlot;
-console.log(response);
+chrome.runtime.sendMessage({greeting: "timeOfDayD3"}, function (response) {
+    var data = response.timeSlot;
+//console.log(response);
 // 	2. Display the scatterplot visualization using D3
     var margin = {top: 20, right: 15, bottom: 60, left: 60};
-	var width = w - margin.left - margin.right;
-	var height = h - margin.top - margin.bottom;
-	var padding = -(margin.left+30);
-    
+    var width = w - margin.left - margin.right;
+    var height = h - margin.top - margin.bottom;
+    var padding = -(margin.left + 30);
+
     var x = d3.scale.linear()
-              .domain([0, d3.max(data, function(d) { return d.time;})])
-              .range([ 0, width ]);
-    
+        .domain([0, d3.max(data, function (d) {
+            return d.time;
+        })])
+        .range([0, width]);
+
     var y = d3.scale.linear()
-    	      .domain([0, d3.max(data, function(d) { return d.rate; })])
-    	      .range([ height, 0 ]);
- 
+        .domain([0, d3.max(data, function (d) {
+            return d.rate;
+        })])
+        .range([height, 0]);
+
     var chart = d3.select('body')
-	.append('svg:svg')
-	.attr('width', width + margin.right + margin.left)
-	.attr('height', height + margin.top + margin.bottom)
-	.attr('class', 'chart');
+        .append('svg:svg')
+        .attr('width', width + margin.right + margin.left)
+        .attr('height', height + margin.top + margin.bottom)
+        .attr('class', 'chart');
 
     var main = chart.append('g')
-	.attr('transform', 'translate(' + margin.left + ',' + margin.top + ')')
-	.attr('width', width)
-	.attr('height', height)
-	.attr('class', 'main');
-        
+        .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')')
+        .attr('width', width)
+        .attr('height', height)
+        .attr('class', 'main');
+
     // draw the x axis
     var xAxis = d3.svg.axis()
-	.scale(x)  
-	.orient('bottom');
-	
-	chart.append("text")
-		.attr("class", "x label")
-		.attr("text-anchor", "end")
-		.attr("x", (width+margin.left+margin.right)/2+margin.left)
-		.attr("y", height + 60)
-		.text("Minutes since midnite");
+        .scale(x)
+        .orient('bottom');
+
+    chart.append("text")
+        .attr("class", "x label")
+        .attr("text-anchor", "end")
+        .attr("x", (width + margin.left + margin.right) / 2 + margin.left)
+        .attr("y", height + 60)
+        .text("Minutes Since Midnight");
 
     main.append('g')
-	.attr('transform', 'translate(0,' + height + ')')
-	.attr('class', 'main axis date')
-	.call(xAxis);
-	
+        .attr('transform', 'translate(0,' + height + ')')
+        .attr('class', 'main axis date')
+        .call(xAxis);
+
     // draw the y axis
     var yAxis = d3.svg.axis()
-	.scale(y)
-	.orient('left');
+        .scale(y)
+        .orient('left');
 
     main.append('g')
-	.attr('transform', 'translate(0,0)')
-	.attr('class', 'axis')
-	.call(yAxis);
+        .attr('transform', 'translate(0,0)')
+        .attr('class', 'axis')
+        .call(yAxis);
 
-    var g = main.append("svg:g"); 
-    
+    var g = main.append("svg:g");
+
     g.selectAll("scatter-dots")
-      .data(data)
-      .enter().append("svg:circle")
-          .attr("cx", function (d,i) { return x(d.time); } )
-          .attr("cy", function (d) { return y(d.rate); } )
-          .attr("fill", "none")
-          .attr("stroke", "steelblue")
-          .attr("stroke-width", 2.0)
-          .attr("r", 3.5);
-          
+        .data(data)
+        .enter().append("svg:circle")
+        .attr("cx", function (d, i) {
+            return x(d.time);
+        })
+        .attr("cy", function (d) {
+            return y(d.rate);
+        })
+        .attr("fill", "none")
+        .attr("stroke", "steelblue")
+        .attr("stroke-width", 2.0)
+        .attr("r", 3.5);
 
-	main.append("text")
-		.attr("text-anchor", "middle")  // this makes it easy to centre the text as the transform is applied to the anchor
-		.attr("transform", "translate("+ (padding/2) +","+(height/2)+")rotate(-90)")  // text is drawn off the screen top left, move down and out and rotate
-		.text("Visits");
+
+    main.append("text")
+        .attr("text-anchor", "middle")
+        // text is drawn off the screen top left, move down and out and rotate
+        .attr("transform", "translate(" + (padding / 2) + "," + (height / 2) + ")rotate(-90)")
+        .text("Visits");
 });

--- a/dataExt/topVisitsD3.js
+++ b/dataExt/topVisitsD3.js
@@ -5,7 +5,7 @@
 
 /* Overall strategy
  *  1. Send message to the listener on background page to send query data
- * 	2. Use alaSQL to select the top n, merged fields, counts and sorted final data 
+ * 	2. Use alaSQL to select the top n, merged fields, counts and sorted final data
  * 	3. Present the D3 bargraph visualization
  */
 var maxDataRows = 35;	//max number of domains to display
@@ -15,9 +15,10 @@ var numDays = 1;		//0 - all time, 1 - 1 day, 7 - 1 week, 30-30days, etc
 var strokecolor = "#000000";
 
 //  1. Send message to the listener on background page to send query data
-chrome.runtime.sendMessage({greeting: "topVisitsD3", rows: maxDataRows, sort: "DESC", days: numDays}, function(response) {
+chrome.runtime.sendMessage({greeting: "topVisitsD3", rows: maxDataRows,
+                            sort: "DESC", days: numDays}, function(response) {
 	var dataset = response.history;
-	console.log(dataset);
+	//console.log(dataset);
 
 // 	3. Present the D3 bargraph visualization
      // Dimensions for the chart: height, width, and space b/t the bars
@@ -35,7 +36,7 @@ chrome.runtime.sendMessage({greeting: "topVisitsD3", rows: maxDataRows, sort: "D
 		.style("visibility", "hidden")
 		.style("top", "60px")
 		.style("left", "125px");
-    
+
 	var yScale = d3.scale.linear()
 		.domain([0, d3.max(dataset, function(d){return d.visits;})])
 		.range([height, 0]);
@@ -78,13 +79,13 @@ chrome.runtime.sendMessage({greeting: "topVisitsD3", rows: maxDataRows, sort: "D
 					.classed("hover", true)
 				//attr("stroke", strokecolor)
 					.attr("stroke-width", "0.5px");
-				tooltip.html( "<p>" + d.domain + "-" + d.visits + " visits</p>" ).style("visibility", "visible");
+				tooltip.html( "<p>" + d.domain + " - " + d.visits + " visits</p>" ).style("visibility", "visible");
 			})
-			
+
 			.on("mouseout", function(d,i) {
 				d3.select(this)
 					.attr("stroke-width", "0px");
-				tooltip.html( "<p>" + d.domain + "-" + d.visits+ " visits</p>" ).style("visibility", "hidden");
+				tooltip.html( "<p>" + d.domain +  " - " + d.visits+ " visits</p>" ).style("visibility", "hidden");
 		});
 
 	// Appends the yAxis

--- a/dataExt/viz1.html
+++ b/dataExt/viz1.html
@@ -5,7 +5,7 @@
 	body {
 		font: 12px verdana;
 	}
-	
+
 	text {
 		font: 12px helvetica;
 	}
@@ -13,15 +13,13 @@
 	div {
 		line-height: 1;
 		font: 14px verdana;
-		font-weight: bold;
-		padding: 12px;
 		border-radius: 2px;
 	}
 
 	rect:hover {
         fill: Silver;
     }
-    
+
 	.axis path,
 	.axis line {
 		fill: none;
@@ -31,12 +29,23 @@
 
 </style>
   <head>
-    <title>BRAVO Visualization I</title>
     <script type=text/javascript src="https://d3js.org/d3.v3.js"></script>
 
   </head>
   <body>
-    <h1 style="font-family:verdana, monospace;">Visualization 1</h1>
+  <div class="title"></div>
+  <p
+  <label for="topvisits"
+         style="font-family: verdana,serif;
+                width: 900px;
+                margin-left: 0;
+                margin-right: 0;
+                font-size: 22px;
+                text-align: center">
+    Cumulative Visits by Top Domains
+  </label>
+  </p>
+
     <div class="main">
     </div>
     <script type="text/javascript" src="topVisitsD3.js">

--- a/dataExt/viz3.html
+++ b/dataExt/viz3.html
@@ -12,18 +12,26 @@
         stroke: black;
         shape-rendering: crispEdges;
       }
-      
+
 </style>
   <head>
-    <title>BRAVO Visualization I</title>
     <script type=text/javascript src="https://d3js.org/d3.v3.js"></script>
   </head>
 
   <body>
-    <h1 style="font-family:verdana, monospace;">Visualization 3</h1>
-    <div class="main">
-      <p><span style = "font-size: 14px;" /span>Visits by time-of-day (15 min increments since midnite)</p>
-    </div>
+  <div class="title"></div>
+  <p
+  <label for="timeofday"
+         style="font-family: verdana,serif;
+                width: 900px;
+                margin-left: 0;
+                margin-right: 0;
+                font-size: 22px;
+                text-align: center">
+    Visits by Time of Day (15 min increments)
+  </label>
+  </p>
+  <div class="chart"></div>
     <script type="text/javascript" src="timeofdayD3.js">
     </script>
   </body>

--- a/dataExt/viz4.html
+++ b/dataExt/viz4.html
@@ -5,26 +5,30 @@
     <script type=text/javascript src="https://d3js.org/d3.v3.js"></script>
     <script type = "text/javascript" src="d3.layout.cloud.js"></script>
   </head>
-  
+
   <style>
     body {
         font-family:"Lucida Grande","Droid Sans",Arial,Helvetica,sans-serif;
     }
-    .bld {
-        font-weight: bold;
-    }
+
   </style>
 
   <body>
-    <h1 style="font-family:verdana, monospace;">Visualization 4</h1>
-    <div class="main">
-      <p><span style = "font-size: 16px;" /span>Wordcloud - all visits</p>
-    </div>
-    <div style="width: 40%;">
+  <div class="title"></div>
+  <p
+  <label for="wordcloud"
+         style="font-family: verdana,serif;
+                width: 900px;
+                margin-left: 0;
+                margin-right: 0;
+                font-size: 22px;
+                text-align: center">
+    Top Domains Visited
+  </label>
+  </p>
+  <div class="chart"></div>
 
-</div>
 
-    
     <script type="text/javascript" src="wordCloudD3.js">
     </script>
   </body>

--- a/dataExt/wordCloudD3.js
+++ b/dataExt/wordCloudD3.js
@@ -9,7 +9,7 @@
  * 	3. Display the wordCloud
  */
 
-var maxFont = 100;  
+var maxFont = 100;
 var minFont = 30;
 var w = 800;
 var h = 500;
@@ -17,11 +17,11 @@ var maxDataRows = 30; 	//max words in the wordCloud
 var numDays = 0;		//0 - all time, 1 - 1 day, 7 - 1 week, 30-30days, etc
 
 //  1. Get the data from listener running on the background page
-chrome.runtime.sendMessage({greeting: "wordCloudD3", rows: maxDataRows, sort: "DESC", days: numDays}, 
-	function(response) {
-	var frequencyList = response.wordList;
+chrome.runtime.sendMessage({greeting: "wordCloudD3", rows: maxDataRows, sort: "DESC", days: numDays},
+    function(response) {
+    var frequencyList = response.wordList;
 	var i;
-console.log(frequencyList);
+    //console.log(frequencyList);
 // 2. Scale the fontsize for the wordCloud
 	var maxSize = Math.max.apply(Math,frequencyList.map(function(o){return o.size;}));
 	var minSize = Math.min.apply(Math,frequencyList.map(function(o){return o.size;}));


### PR DESCRIPTION
Fixed/added titles, axes, and buttons for these visualizations. Added a slider to the streamgraph to select a number of domains. Various jshint cleanup. Chrome history data is now retrieved once when the extension is loaded and on-demand when visualizations are loaded. This improves performance and user experience.   

**Note:** When I used my IDE to cleanup the code with jshint, it changed the end-of-line character on many of the files, making it look like there were code changes in the 'diff' when just the end-of-line changed.